### PR TITLE
feat: add TextTyper scene

### DIFF
--- a/src/projects/shlagemon/shlagemon.project.ts
+++ b/src/projects/shlagemon/shlagemon.project.ts
@@ -1,11 +1,6 @@
-import { makeProject } from "@motion-canvas/core";
-import scene from "../../scenes/code?scene";
-
-import { parser } from "@lezer/javascript";
-import { Code, LezerHighlighter } from "@motion-canvas/2d";
-
-Code.defaultHighlighter = new LezerHighlighter(parser);
+import {makeProject} from "@motion-canvas/core";
+import textTyper from "../../scenes/text-typer?scene";
 
 export default makeProject({
-  scenes: [scene],
+  scenes: [textTyper],
 });

--- a/src/scenes/text-typer.meta
+++ b/src/scenes/text-typer.meta
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "timeEvents": [],
+  "seed": 0
+}

--- a/src/scenes/text-typer.tsx
+++ b/src/scenes/text-typer.tsx
@@ -1,0 +1,39 @@
+import {Rect, Txt, makeScene2D} from '@motion-canvas/2d';
+import {createRef, waitFor} from '@motion-canvas/core';
+import {theme} from '../theme';
+
+/**
+ * TextTyper scene displaying text with a typewriter effect.
+ */
+export default makeScene2D(function* TextTyper(view) {
+  const textRef = createRef<Txt>();
+  const content = "J'ai codé un jeu";
+  const totalDuration = 3;
+  const step = totalDuration / content.length;
+
+  view.add(
+    <Rect
+      layout
+      width={'100%'}
+      height={'100%'}
+      fill={'#000'}
+      justifyContent={'center'}
+      alignItems={'center'}
+    >
+      <Txt
+        ref={textRef}
+        text=""
+        fontFamily={theme.font}
+        fontSize={96}
+        fill={'#fff'}
+      />
+    </Rect>,
+  );
+
+  let currentText = '';
+  for (const char of content) {
+    currentText += char;
+    textRef().text(currentText);
+    yield* waitFor(step);
+  }
+});


### PR DESCRIPTION
## Summary
- replace shlagemon project scene with new TextTyper
- implement typewriter animation for text

## Testing
- `npm run build` (fails: Cannot find module '../components/switch')

------
https://chatgpt.com/codex/tasks/task_e_68980fb9066c832a96f04fa8290b5022