### PR TITLE
feat: add typewriter audio with pooling

### DIFF
--- a/src/scenes/text-typer.tsx
+++ b/src/scenes/text-typer.tsx
@@ -1,15 +1,19 @@
 import {Rect, Txt, makeScene2D} from '@motion-canvas/2d';
 import {createRef, waitFor} from '@motion-canvas/core';
 import {theme} from '../theme';
+import {createAudioPool} from '../utils/audioPool';
 
 /**
- * TextTyper scene displaying text with a typewriter effect.
+ * TextTyper scene displaying text with a typewriter effect and sound.
  */
 export default makeScene2D(function* TextTyper(view) {
   const textRef = createRef<Txt>();
   const content = "J'ai codé un jeu";
   const totalDuration = 3;
   const step = totalDuration / content.length;
+
+  const typePool = createAudioPool('/sfx/typing/type.wav', 8, 0.05);
+  const spacePool = createAudioPool('/sfx/typing/space.wav', 4, 0.05);
 
   view.add(
     <Rect
@@ -34,6 +38,13 @@ export default makeScene2D(function* TextTyper(view) {
   for (const char of content) {
     currentText += char;
     textRef().text(currentText);
+
+    if (char === ' ') {
+      spacePool.play();
+    } else {
+      typePool.play();
+    }
+
     yield* waitFor(step);
   }
 });

--- a/src/utils/audioPool.ts
+++ b/src/utils/audioPool.ts
@@ -1,0 +1,39 @@
+/**
+ * AudioPool manages a set of Audio elements for a given source file.
+ * It allows overlapping playback without cutting sounds prematurely.
+ */
+export interface AudioPool {
+  /**
+   * Play the next audio instance with a slight random playback rate variation.
+   */
+  play(): void;
+}
+
+/**
+ * Create an AudioPool.
+ *
+ * @param source - Path to the audio file.
+ * @param poolSize - Number of audio instances to keep in the pool.
+ * @param rateVariation - Maximum random variation applied to playbackRate.
+ */
+export function createAudioPool(
+  source: string,
+  poolSize: number,
+  rateVariation: number = 0,
+): AudioPool {
+  const pool = Array.from({length: poolSize}, () => new Audio(source));
+  let index = 0;
+
+  return {
+    play(): void {
+      const audio = pool[index];
+      index = (index + 1) % pool.length;
+
+      audio.pause();
+      audio.currentTime = 0;
+      const variation = 1 + (Math.random() * 2 - 1) * rateVariation;
+      audio.playbackRate = variation;
+      void audio.play();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable `createAudioPool` utility for overlapping playback with random pitch
- enhance TextTyper scene with pooled sounds for letters and spaces

## Testing
- `npm run build` *(fails: src/scenes/components.tsx(3,24): Cannot find module '../components/switch')*

------
https://chatgpt.com/codex/tasks/task_e_689815633198832a94ffc87c3aecc4aa